### PR TITLE
Add missing Drift import for electric types

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,6 +70,8 @@ import 'dart:io';
 
 import 'package:drift/native.dart';
 import 'package:myapp/generated/electric/drift_schema.dart';
+// [IMPORTANT] Add this line to enable the import of electric types for Drift
+import 'package:electricsql/drivers/drift.dart'; 
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 


### PR DESCRIPTION
Hello and thank you very much for this project! 🙏

Just a small proposal to complete the documentation on integrating Electric into an existing Flutter application.

I had a compilation error for the missing Electric types in the database file generated by Drift without this import.

Have a nice day!