### PR TITLE
Support postgres, add simple backend to example

### DIFF
--- a/packages/electricsql/lib/src/client/model/schema.dart
+++ b/packages/electricsql/lib/src/client/model/schema.dart
@@ -66,12 +66,10 @@ class DBSchemaDrift implements DBSchema {
     //print("Column: ${c.name}  ${c.type}   ${c.driftSqlType}");
     final type = c.type;
     switch (type) {
+      case CustomElectricType():
+        return type.pgType;
       case CustomSqlType<Object>():
-        if (type is CustomElectricType) {
-          return type.pgType;
-        } else {
-          return null;
-        }
+        return null;
       case DriftSqlType.bool:
         return PgType.bool;
       case DriftSqlType.string:

--- a/todos_flutter/bin/backend.dart
+++ b/todos_flutter/bin/backend.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart';
+import 'package:shelf_router/shelf_router.dart';
+import 'package:todos_electrified/database/drift/database.dart';
+import 'package:drift_postgres/drift_postgres.dart';
+import 'package:postgres/postgres.dart';
+
+void main() async {
+  final database = AppDatabase(
+    PgDatabase(
+      endpoint: Endpoint(
+        host: 'localhost',
+        database: 'postgres',
+        port: 65432,
+        username: 'postgres',
+        password: 'proxy_password',
+      ),
+      settings: const ConnectionSettings(sslMode: SslMode.disable),
+      // We're using dbmate to manage migrations
+      enableMigrations: false,
+    ),
+  );
+
+  Future<Response> listAll(Request request) async {
+    final entries = await database.todo.all().get();
+
+    return Response.ok(
+      json.encode(entries),
+      headers: {'Content-Type': 'application/json'},
+    );
+  }
+
+  final router = Router()..get('/', listAll);
+  final handler = const Pipeline().addHandler(router.call);
+
+  await serve(handler.call, 'localhost', 8080);
+  print('Listening on http://localhost:8080/');
+}

--- a/todos_flutter/build.yaml
+++ b/todos_flutter/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      drift_dev:
+        options:
+          sql:
+            dialects: [sqlite, postgres]

--- a/todos_flutter/lib/database/drift/database.dart
+++ b/todos_flutter/lib/database/drift/database.dart
@@ -1,103 +1,12 @@
 import 'package:drift/drift.dart';
 import 'package:electricsql_flutter/drivers/drift.dart';
-import 'package:todos_electrified/database/database.dart' as m;
 import 'package:todos_electrified/generated/electric/drift_schema.dart';
-import 'connection/connection.dart' as impl;
 
 part 'database.g.dart';
 
-Future<DriftRepository> initDriftTodosDatabase() async {
-  final db = AppDatabase();
-
-  await db.customSelect("SELECT 1").get();
-
-  return DriftRepository(db);
-}
-
-class DriftRepository implements m.TodosRepository {
-  final AppDatabase db;
-
-  DriftRepository(this.db);
-
-  @override
-  Future<void> close() async {
-    await db.close();
-  }
-
-  @override
-  Future<List<m.Todo>> fetchTodos() async {
-    return (db.todo.select()
-          ..orderBy(
-            [(tbl) => OrderingTerm(expression: tbl.text$.lower())],
-          ))
-        .map(
-          (todo) => m.Todo(
-            completed: todo.completed,
-            id: todo.id,
-            listId: todo.listid,
-            editedAt: todo.editedAt,
-            text: todo.text$!,
-          ),
-        )
-        .get();
-  }
-
-  @override
-  Future<void> insertTodo(m.Todo todo) async {
-    await db.todo.insertOne(
-      TodoCompanion.insert(
-        id: todo.id,
-        completed: todo.completed,
-        listid: Value(todo.listId),
-        text$: Value(todo.text),
-        editedAt: todo.editedAt,
-      ),
-    );
-  }
-
-  @override
-  Future<void> removeTodo(String id) async {
-    await db.todo.deleteWhere((tbl) => tbl.id.equals(id));
-  }
-
-  @override
-  Future<void> updateTodo(m.Todo item) async {
-    await (db.todo.update()
-          ..where(
-            (tbl) => tbl.id.equals(item.id),
-          ))
-        .write(
-      TodoCompanion(
-        completed: Value(item.completed),
-        listid: Value(item.listId),
-        text$: Value(item.text),
-        editedAt: Value(DateTime.now()),
-      ),
-    );
-  }
-
-  @override
-  Stream<List<m.Todo>> watchTodos() {
-    return (db.todo.select()
-          ..orderBy(
-            [(tbl) => OrderingTerm(expression: tbl.text$.lower())],
-          ))
-        .map(
-          (todo) => m.Todo(
-            completed: todo.completed,
-            id: todo.id,
-            listId: todo.listid,
-            editedAt: todo.editedAt,
-            text: todo.text$!,
-          ),
-        )
-        .watch();
-  }
-}
-
 @DriftDatabase(tables: kElectrifiedTables)
 class AppDatabase extends _$AppDatabase {
-  AppDatabase() : super(impl.connect());
+  AppDatabase(super.e);
 
   @override
   int get schemaVersion => 1;

--- a/todos_flutter/lib/database/drift/database.g.dart
+++ b/todos_flutter/lib/database/drift/database.g.dart
@@ -26,12 +26,14 @@ class $TodoTable extends Todo with TableInfo<$TodoTable, TodoData> {
   static const VerificationMeta _completedMeta =
       const VerificationMeta('completed');
   @override
-  late final GeneratedColumn<bool> completed = GeneratedColumn<bool>(
-      'completed', aliasedName, false,
-      type: DriftSqlType.bool,
-      requiredDuringInsert: true,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('CHECK ("completed" IN (0, 1))'));
+  late final GeneratedColumn<bool> completed =
+      GeneratedColumn<bool>('completed', aliasedName, false,
+          type: DriftSqlType.bool,
+          requiredDuringInsert: true,
+          defaultConstraints: GeneratedColumn.constraintsDependsOnDialect({
+            SqlDialect.sqlite: 'CHECK ("completed" IN (0, 1))',
+            SqlDialect.postgres: '',
+          }));
   static const VerificationMeta _editedAtMeta =
       const VerificationMeta('editedAt');
   @override

--- a/todos_flutter/lib/database/drift/drift_repository.dart
+++ b/todos_flutter/lib/database/drift/drift_repository.dart
@@ -1,0 +1,94 @@
+import 'package:drift/drift.dart';
+import 'package:todos_electrified/database/database.dart' as m;
+
+import 'database.dart';
+import 'connection/connection.dart' as impl;
+
+Future<DriftRepository> initDriftTodosDatabase() async {
+  final db = AppDatabase(impl.connect());
+
+  await db.customSelect("SELECT 1").get();
+
+  return DriftRepository(db);
+}
+
+class DriftRepository implements m.TodosRepository {
+  final AppDatabase db;
+
+  DriftRepository(this.db);
+
+  @override
+  Future<void> close() async {
+    await db.close();
+  }
+
+  @override
+  Future<List<m.Todo>> fetchTodos() async {
+    return (db.todo.select()
+          ..orderBy(
+            [(tbl) => OrderingTerm(expression: tbl.text$.lower())],
+          ))
+        .map(
+          (todo) => m.Todo(
+            completed: todo.completed,
+            id: todo.id,
+            listId: todo.listid,
+            editedAt: todo.editedAt,
+            text: todo.text$!,
+          ),
+        )
+        .get();
+  }
+
+  @override
+  Future<void> insertTodo(m.Todo todo) async {
+    await db.todo.insertOne(
+      TodoCompanion.insert(
+        id: todo.id,
+        completed: todo.completed,
+        listid: Value(todo.listId),
+        text$: Value(todo.text),
+        editedAt: todo.editedAt,
+      ),
+    );
+  }
+
+  @override
+  Future<void> removeTodo(String id) async {
+    await db.todo.deleteWhere((tbl) => tbl.id.equals(id));
+  }
+
+  @override
+  Future<void> updateTodo(m.Todo item) async {
+    await (db.todo.update()
+          ..where(
+            (tbl) => tbl.id.equals(item.id),
+          ))
+        .write(
+      TodoCompanion(
+        completed: Value(item.completed),
+        listid: Value(item.listId),
+        text$: Value(item.text),
+        editedAt: Value(DateTime.now()),
+      ),
+    );
+  }
+
+  @override
+  Stream<List<m.Todo>> watchTodos() {
+    return (db.todo.select()
+          ..orderBy(
+            [(tbl) => OrderingTerm(expression: tbl.text$.lower())],
+          ))
+        .map(
+          (todo) => m.Todo(
+            completed: todo.completed,
+            id: todo.id,
+            listId: todo.listid,
+            editedAt: todo.editedAt,
+            text: todo.text$!,
+          ),
+        )
+        .watch();
+  }
+}

--- a/todos_flutter/lib/init.dart
+++ b/todos_flutter/lib/init.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:todos_electrified/database/database.dart';
 import 'package:todos_electrified/database/drift/database.dart';
+import 'package:todos_electrified/database/drift/drift_repository.dart';
 import 'package:todos_electrified/electric.dart';
 import 'package:todos_electrified/theme.dart';
 import 'package:todos_electrified/util/confirmation_dialog.dart';

--- a/todos_flutter/pubspec.lock
+++ b/todos_flutter/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  buffer:
+    dependency: transitive
+    description:
+      name: buffer
+      sha256: "94f60815065a8f0fd4f05be51faf86cf86519327e039d5c2aac72e1d1cc1dad4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
   build:
     dependency: transitive
     description:
@@ -265,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.15.0"
+  drift_postgres:
+    dependency: "direct main"
+    description:
+      name: drift_postgres
+      sha256: "53970a18e2a30ab67acb804cecd79b4e81b3f92c31d5db027acdedab3374e8be"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   ed25519_edwards:
     dependency: transitive
     description:
@@ -424,6 +440,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      sha256: "6bccce8f1ec7b5d701e7921dca35e202d425b57e317ba1a37f2638590e29e566"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -624,6 +648,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -672,6 +704,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  postgres:
+    dependency: "direct main"
+    description:
+      name: postgres
+      sha256: "0178bf02b520ad5d40ac9d83a77a337177b4a0b5599b3e0ed3c356f626457aaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.8"
   protobuf:
     dependency: transitive
     description:
@@ -736,14 +776,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
-  shelf:
+  sasl_scram:
     dependency: transitive
+    description:
+      name: sasl_scram
+      sha256: a47207a436eb650f8fdcf54a2e2587b850dc3caef9973ce01f332b07a6fc9cb9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
+  saslprep:
+    dependency: transitive
+    description:
+      name: saslprep
+      sha256: "79c9e163a82f55da542feaf0f7a59031e74493299c92008b2b404cd88d639bb4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
+  shelf:
+    dependency: "direct main"
     description:
       name: shelf
       sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  shelf_router:
+    dependency: "direct main"
+    description:
+      name: shelf_router
+      sha256: f5e5d492440a7fb165fe1e2e1a623f31f734d3370900070b2b1e0d0428d59864
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.4"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -885,6 +949,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  unorm_dart:
+    dependency: transitive
+    description:
+      name: unorm_dart
+      sha256: "5b35bff83fce4d76467641438f9e867dc9bcfdb8c1694854f230579d68cd8f4b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   uuid:
     dependency: transitive
     description:

--- a/todos_flutter/pubspec.yaml
+++ b/todos_flutter/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   # https://github.com/simolus3/sqlite3.dart/releases?q=sqlite3_flutter_libs&expanded=true
   sqlite3_flutter_libs: 0.5.19+1
 
-  # THese are only used for the backend example, they are not needed to use Eletric
+  # THese are only used for the backend example, they are not needed to use Electric
   # in Flutter apps.
   postgres: ^3.0.8
   drift_postgres: ^1.1.0

--- a/todos_flutter/pubspec.yaml
+++ b/todos_flutter/pubspec.yaml
@@ -32,6 +32,13 @@ dependencies:
   # https://github.com/simolus3/sqlite3.dart/releases?q=sqlite3_flutter_libs&expanded=true
   sqlite3_flutter_libs: 0.5.19+1
 
+  # THese are only used for the backend example, they are not needed to use Eletric
+  # in Flutter apps.
+  postgres: ^3.0.8
+  drift_postgres: ^1.1.0
+  shelf: ^1.4.1
+  shelf_router: ^1.1.4
+
 dev_dependencies:
   build_runner: ^2.4.4
   drift_dev: 2.15.0


### PR DESCRIPTION
Hi :wave: Since drift also supports accessing postgres databases, I wanted to see what it takes to connect to postgres databases via the drift database generated by this package. As it turns out, not many changes are needed at all. I think the biggest change is that the custom types don't need to do any mappings when talking to a postgres database (at least that seems to make them work for the timezone column in the example).

As a proof-of-concept, I've added a very simple backend to the todo app example. It serves all todos by connecting to the postgres database through the electric proxy. At the moment this is all quite hacky, I've just done the minimal work required for that not to crash :D I also had to move some files around to avoid importing `dart:ui` in the backend.

If you think postgres support looks promising / is something worth doing, I'm happy to get this into a merge-able state. I want to highlight some synchronization solutions on drift's documentation website, and being able to point to a (sort-of) fullstack example would be pretty neat.